### PR TITLE
Only changed one line

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -299,6 +299,7 @@ h1, h2, h3, h4, h5, h6, figure {
   height: 900px;
   background-size: cover;
   background-repeat: no-repeat;
+  background-position: center !important;
   position: relative;
   width: 100%;
 }


### PR DESCRIPTION
Bootstrap overrides certain things so when you center the background image you have to put !important next to it.